### PR TITLE
Удаление - Острый печёночный фармакокинез

### DIFF
--- a/code/__SPLURTCODE/DEFINES/traits.dm
+++ b/code/__SPLURTCODE/DEFINES/traits.dm
@@ -16,7 +16,6 @@
 #define TRAIT_TOUGHT					"tought"
 
 // Hyperstation traits
-#define TRAIT_PHARMA            		"hepatic_pharmacokinesis"
 #define TRAIT_CHOKE_SLUT				"choke_slut"
 #define TRAIT_BLOODFLEDGE				"bloodfledge"
 #define TRAIT_INCUBUS					"incubus"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -155,12 +155,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 		for(var/V in all_quirks) // quirk migration
 			switch(V)
-				if("Acute hepatic pharmacokinesis")
-					cit_toggles &= ~(PENIS_ENLARGEMENT)
-					cit_toggles &= ~(BREAST_ENLARGEMENT)
-					cit_toggles |= FORCED_FEM
-					cit_toggles |= FORCED_MASC
-					all_quirks -= V
 				if("Crocin Immunity")
 					cit_toggles |= NO_APHRO
 					all_quirks -= V

--- a/modular_bluemoon/Fink/code/datums/traits/dna_bm.dm
+++ b/modular_bluemoon/Fink/code/datums/traits/dna_bm.dm
@@ -1179,16 +1179,6 @@
 	text_gain_indication = "<span class='notice'>Вы хотите ощутить пальцы вокруг шеи, сжимающие её до тех пор, пока не отключитесь или кончите... а может, всё сразу?</span>"
 	text_lose_indication = "<span class='danger'>Похоже, вас больше не возбуждает асфиксия.</span>"
 
-/datum/mutation/human/bm/pharmacokinesis //Supposed to prevent unwanted organ additions. But i don't think it's really working rn
-	name = "Острый Печеночный Фармакокинез" //copypasting dumbo
-	desc = "У вас генетическое заболевание, которое заставляет печень усваивать семя инкуба и молоко суккуба при попадании их в организм."
-	quality = NEGATIVE
-	difficulty = 8
-	instability = -10
-	mob_trait = TRAIT_PHARMA
-	text_lose_indication = "<span class='danger'>Ваша печень ощущается... по-иному.</span>"
-
-
 /datum/mutation/human/bm/cursed_blood
 	name = "Проклятая Кровь"
 	desc = "На вашем роду лежит проклятие бледной крови. Лучше держаться подальше от святой воды... а вот адской воды, напротив..."

--- a/modular_splurt/code/datums/traits/neutral.dm
+++ b/modular_splurt/code/datums/traits/neutral.dm
@@ -8,16 +8,6 @@
 	gain_text = span_notice("Вы хотите ощутить пальцы вокруг шеи, сжимающие её до тех пор, пока не отключитесь или кончите... а может, всё сразу?")
 	lose_text = span_notice("Похоже, вас больше не возбуждает асфиксия.")
 
-/datum/quirk/pharmacokinesis //Supposed to prevent unwanted organ additions. But i don't think it's really working rn
-	name = "Острый Печеночный Фармакокинез" //copypasting dumbo
-	desc = "У вас генетическое заболевание, которое заставляет печень усваивать семя инкуба и молоко суккуба при попадании их в организм."
-	value = 0
-	mob_trait = TRAIT_PHARMA
-	lose_text = span_notice("Ваша печень ощущается... по-иному.")
-	var/active = FALSE
-	var/power = 0
-	var/cachedmoveCalc = 1
-
 /datum/quirk/cursed_blood
 	name = "Проклятая Кровь"
 	desc = "На вашем роду лежит проклятие бледной крови. Лучше держаться подальше от святой воды... а вот адской воды, напротив..."


### PR DESCRIPTION
Квирк не используется, потому что всё связанное с ним уже выполняют префы.

